### PR TITLE
Fixed the issues for deploying pyDIFI to pypi from Github 

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -63,6 +63,7 @@ jobs:
 
   release:
     name: Create GitHub Release
+    if: ${{ contains( github.ref_name, 'rc' ) }}
     runs-on: ubuntu-latest
     needs: [build_wheels, test_artifacts]
 
@@ -78,6 +79,7 @@ jobs:
 
         with:
           files: dist/*.whl
-          draft: ${{ contains( github.ref_name, 'rc' ) }} #Draft if 'rc' (release candidate) in tag e.g. v1.0.0rc0
+          #draft: ${{ contains( github.ref_name, 'rc' ) }} #Draft if 'rc' (release candidate) in tag e.g. v1.0.0rc0
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -1,4 +1,6 @@
 name: Release the wheels to Github Release
+# The wheel is deployed to Github release as draft when the git tag with "rc" is pushed
+# Otherwise, the wheel in only uploaded as artifact and the release is not created.
 
 on:
  push:
@@ -63,6 +65,9 @@ jobs:
 
   release:
     name: Create GitHub Release
+    # Draft if 'rc' (release candidate) in tag e.g. v1.0.0rc0.
+    # The action performed by GITHUB_TOKEN will prevent the event triggered from other workflows.
+    # To release the package to pypi, the release will be triggered manually by the user after the release is created. This is to prevent accidental releases to pypi.
     if: ${{ contains( github.ref_name, 'rc' ) }}
     runs-on: ubuntu-latest
     needs: [build_wheels, test_artifacts]
@@ -79,7 +84,6 @@ jobs:
 
         with:
           files: dist/*.whl
-          #draft: ${{ contains( github.ref_name, 'rc' ) }} #Draft if 'rc' (release candidate) in tag e.g. v1.0.0rc0
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -66,7 +66,8 @@ jobs:
   release:
     name: Create GitHub Release
     # Draft if 'rc' (release candidate) in tag e.g. v1.0.0rc0.
-    # The action performed by GITHUB_TOKEN will prevent the event triggered from other workflows.
+    # This is to avoid the Github secrets (i.e. secrets.GITHUB_TOKEN) was triggered when Release is created.
+    # For safety reason, the tasks performed by GITHUB_TOKEN (i.e. pushing a tag or creating a release) will not trigger further workflows to prevent infinite loops.
     # To release the package to pypi, the release will be triggered manually by the user after the release is created. This is to prevent accidental releases to pypi.
     if: ${{ contains( github.ref_name, 'rc' ) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [created] #Note that draft release will not trigger this type
+    types: [published] #Note that draft release will not trigger this type
 
 jobs:
   deploy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyDIFI"
-version = "8.1.3"
+version = "8.1.4"
 authors = [
     { name="Collin Kadlecek", email="Collin.Kadlecek@colorado.edu" },
   { name="Li-Yin Young", email="liyin.young@colorado.edu" },


### PR DESCRIPTION
- The wheels will be created at Github Release only if the git tag include "rc". Otherwise, it will only create wheels in Github action as artifacts when the tag is created.
- Bumped the version from v8.1.3 to v8.1.4
- This is to avoid the Github secrets (i.e. secrets.GITHUB_TOKEN) was triggered when Release is created. For safety reason, the tasks performed by GITHUB_TOKEN will not trigger further workflows to prevent infinite loops.